### PR TITLE
Compatibility with Ruby 3

### DIFF
--- a/lib/scorm/package.rb
+++ b/lib/scorm/package.rb
@@ -74,7 +74,7 @@ module Scorm
           i = (i || 0) + 1
 
         # Make sure the generated path is unique.
-        end while File.exists?(@path)
+        end while File.exist?(@path)
       end
       
       # Extract the package
@@ -112,7 +112,7 @@ module Scorm
     
     # Cleans up by deleting all extracted files. Called when an error occurs.
     def cleanup
-      FileUtils.rmtree(@path) if @options[:cleanup] && !@options[:dry_run] && @path && File.exists?(@path) && package?
+      FileUtils.rmtree(@path) if @options[:cleanup] && !@options[:dry_run] && @path && File.exist?(@path) && package?
     end
     
     # Extracts the content of the package to the course repository. This will be
@@ -134,7 +134,7 @@ module Scorm
       Zip::ZipFile::foreach(@package) do |entry|
         entry_path = File.join(@path, entry.name)
         entry_dir = File.dirname(entry_path)
-        FileUtils.mkdir_p(entry_dir) unless File.exists?(entry_dir)
+        FileUtils.mkdir_p(entry_dir) unless File.exist?(entry_dir)
         entry.extract(entry_path)
       end
     end
@@ -152,7 +152,7 @@ module Scorm
     # set to +true+ when opening the package the file will <em>not</em> be
     # extracted to the file system, but read directly into memory.
     def file(filename)
-      if File.exists?(@path)
+      if File.exist?(@path)
         File.read(path_to(filename))
       else
         Zip::ZipFile.foreach(@package) do |entry|
@@ -163,8 +163,8 @@ module Scorm
     
     # Returns +true+ if the specified file (or directory) exists in the package.
     def exists?(filename)
-      if File.exists?(@path)
-        File.exists?(path_to(filename))
+      if File.exist?(@path)
+        File.exist?(path_to(filename))
       else
         Zip::ZipFile::foreach(@package) do |entry|
           return true if entry.name == filename

--- a/scorm.gemspec
+++ b/scorm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'scorm'
-  s.version     = '1.0.2'
+  s.version     = '2.0.0'
   s.summary     = 'Ruby library for reading, extracting and generating SCORM files.'
   s.description = 'SCORM is a Ruby library for reading and extracting Shareable Content Object Reference Model (SCORM) files. SCORM is a standardized package format used mainly by e-learning software to help with the exchange of course material between systems in an interoperable way. This gem supports SCORM 1.2 and SCORM 2004.'
 
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.executables        = ['scorm']
   s.default_executable = 'scorm'
 
-  s.add_dependency('rubyzip',  '~> 0.9.4')
+  s.add_dependency('rubyzip',  '~> 2.3.2')
+  s.add_dependency('zip-zip',  '= 0.3')
 end


### PR DESCRIPTION
`File.exists?` was [deprecated](https://ruby-doc.org/core-2.2.0/File.html#exists-3F-method) in Ruby 2.2.0 and removed sometime after. This project contains a few uses and the pinned version of `rubyzip` does as well. This replaces those instances and updates `rubyzip` for compatibility with Ruby 2.2.0 and later.

I took the liberty of bumping the major version since these changes will not be backwards compatible with projects that currently use this gem. Happy to specify a different version number compatible with the maintainers wishes.

## Changes
- Replace File.exists? with File.exist?
- Update rubyzip
- Version bump to 2.0 because of the breaking changes